### PR TITLE
Delete bignum_ptr typedef and set const parameters

### DIFF
--- a/bignum_lib.h
+++ b/bignum_lib.h
@@ -8,27 +8,25 @@ typedef struct bignum
     int sign; // хранит "1", если число неотрицательное, иначе "-1"
 } bignum_t;
 
-typedef bignum_t *bignum_ptr;
+void print_number(const bignum_t *);
 
-void print_number(bignum_ptr num);
-
-bignum_ptr num_init(char *str); /* принимает строку с big-endian числом,
+bignum_t *num_init(const char *); /* принимает строку с big-endian числом,
                                     * возвращает структуру с little-endian
                                     * используется для конвертации строки в структуру */
 
-bignum_ptr add(bignum_ptr num1, bignum_ptr num2);
+bignum_t *add(const bignum_t *, const bignum_t *);
 
-bignum_ptr subtract(bignum_ptr num1, bignum_ptr num2);
+bignum_t *subtract(const bignum_t *,const bignum_t *);
 
-bignum_ptr multiply(bignum_ptr num1, bignum_ptr num2);
+bignum_t *multiply(const bignum_t *, const bignum_t *);
 
-bignum_ptr divide(bignum_ptr num1, bignum_ptr num2);
+bignum_t *divide(const bignum_t *, const bignum_t *);
 
-bignum_ptr division_remainder(bignum_ptr num1, bignum_ptr num2);
+bignum_t *division_remainder(const bignum_t *, const bignum_t *);
 
-char *number_to_string(bignum_ptr num);
+char *number_to_string(const bignum_t *);
 
-void free_num(bignum_ptr num);
+void free_num(bignum_t *);
 
 
 #endif //BIGNUM_LIB_H


### PR DESCRIPTION
Typedef was deleted to avoid mistakes. Most parameters were changed to consts and were unnamed for code quality improvement.